### PR TITLE
Add function to derive tp from tau/chi parameter

### DIFF
--- a/Example.ipynb
+++ b/Example.ipynb
@@ -849,7 +849,7 @@
    "source": [
     "# Bonus utilities\n",
     "\n",
-    "## Add missing parameters\n",
+    "## Calculate missing time of periastron\n",
     "\n",
     "Some parameters are missing from the NASA exoplanet archive. A common example is the time of periastron, which is sometimes instead specify as a transit time (these are usually in the archive), or as $\\tau$ or $\\chi$, which is defined as\n",
     "\n",

--- a/Example.ipynb
+++ b/Example.ipynb
@@ -848,6 +848,59 @@
    "metadata": {},
    "source": [
     "# Bonus utilities\n",
+    "\n",
+    "## Add missing parameters\n",
+    "\n",
+    "Some parameters are missing from the NASA exoplanet archive. A common example is the time of periastron, which is sometimes instead specify as a transit time (these are usually in the archive), or as $\\tau$ or $\\chi$, which is defined as\n",
+    "\n",
+    "$$\n",
+    "\\tau = (t_{\\mathrm{ref}} - t_p) / P\n",
+    "$$\n",
+    "\n",
+    "Where $P$ is the period, $t_p$ the time of periastron and $t_{\\mathrm{ref}}$ is a reference time (often the first observation).\n",
+    "\n",
+    "For many use cases, it is more convenient to have $t_p$, so we provide a utility function to derive it. In the example below, we use this function to obtain $t_p$ for GJ 536 b, based on results from [Mascareño et al. (2017)](https://ui.adsabs.harvard.edu/abs/2017A%26A...597A.108S/abstract). The values for $\\tau$ and $P$ are in the paper ($\\tau$ is labeled $\\chi$), and the first observation time can be found from [the RV data](http://cdsarc.u-strasbg.fr/viz-bin/qcat?J/A+A/597/A108#/browse)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tp for GJ 536 b is 2453194.91 +/- 0.87\n"
+     ]
+    }
+   ],
+   "source": [
+    "from astropy import uncertainty as unc\n",
+    "import numpy as np\n",
+    "import exofile.utils as ut\n",
+    "\n",
+    "tref = 3202.5590 + 2450000\n",
+    "n_samples = 10_000\n",
+    "per = unc.normal(8.7076, std=np.mean([0.0022, 0.0025]), n_samples=n_samples)\n",
+    "tau = unc.normal(0.88, std=np.mean([0.08, 0.12]), n_samples=n_samples)\n",
+    "\n",
+    "tp, tp_err = np.round(ut.get_tp_from_tau(tau, per, tref), 2)\n",
+    "\n",
+    "print(f\"Tp for GJ 536 b is {tp} +/- {tp_err}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We could then add these values to a custom exofile so that they are stored somewhere for future use."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Accessing tables from NASA exoplanet archive\n",
     "The Planetary System and Planetary System Composite Parameters tables be\n",
     "queried with `exofile`. The PS table has one entry for every parameter set\n",
@@ -2157,9 +2210,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "exofile",
    "language": "python",
-   "name": "python3"
+   "name": "exofile"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This adds a function to convert the "tau"  or "chi" parameter sometimes used to define time of periastron (modulo period with some reference time) to an actual time of periastron. I put it in the `utils` module and added an example in the notebook. Given that Tp seems to be the most common missing orbital parameter in the archive, often because only tau is given, I think this can be of general use if someone needs to add Tp in their custom exofile or Google sheet.