### PR TITLE
Preserve existing mask in `nan_to_mask`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ exofile_alt.ecsv
 exofile_custom.ecsv
 exofile_ref.ecsv
 Exoplanet_Archive_Column_Mapping_CSV.csv
+new_google_sheet.csv
 
 ################
 # Mac OS related

--- a/exofile/table_custom.py
+++ b/exofile/table_custom.py
@@ -95,7 +95,7 @@ class Table(table.Table):
         if self.masked:
             for k in self.keys():
                 if self[k].dtype == float:
-                    self[k].mask = np.isnan(self[k])
+                    self[k].mask = np.isnan(self[k]) | self[k].mask
         else:
             raise TypeError("Input must be a Masked Table." +
                             "\n \t Set its mask to True before calling" +


### PR DESCRIPTION
I looked a bit more into #24 and the cause for new 0 values in the empty cells seemed to be that `table_custom.Table.nan_to_mask()` was setting the mask to `True` only where the existing values were `nan`, so the originally masked values were unmasked by the operation.

This ensures masked values are still masked after running `nan_to_mask()` and fixes #24.