### PR TITLE
Ignore `SkyCoord` in `nan_to_mask()`

### DIFF
--- a/exofile/archive.py
+++ b/exofile/archive.py
@@ -457,7 +457,7 @@ class ExoFile(Table):
             new = new[pc_cols]
 
             # Safety check
-            if len(difference(new.colnames, pc_cols)) > 0 or len(difference(pc_cols, new.colnames)):
+            if len(difference(new.colnames, pc_cols)) > 0 or len(difference(pc_cols, new.colnames)) > 0:
                 raise RuntimeError(
                     f"The formatted {tbl_id} table is incompatible with the masterfile/composite table format"
                 )

--- a/exofile/table_custom.py
+++ b/exofile/table_custom.py
@@ -102,7 +102,7 @@ class Table(table.Table):
         """
         if self.masked:
             for k in self.keys():
-                if self[k].dtype == float:
+                if not isinstance(self[k], SkyCoord) and self[k].dtype == float:
                     self[k].mask = np.isnan(self[k]) | self[k].mask
         else:
             raise TypeError("Input must be a Masked Table." +


### PR DESCRIPTION
Not sure if this is what removed some columns from the alt file, but maybe. It's still good to fix it because it might will break other things anyway.

Basically, using `.dtype` on a `SkyCoord` column causes an error. So before using dtype we need to check if the colum is a `SkyCoord`.