### PR TITLE
Ensure astroquery >= 0.4.4 to have ipac namespace

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ packages = find:
 include_package_data = True
 install_requires =
     numpy
-    astropy
+    astropy >= 0.4.4
     requests
     pyyaml
     astroquery


### PR DESCRIPTION
Fixes #41.